### PR TITLE
Add XCTest dependency to StagehandTesting

### DIFF
--- a/Stagehand.podspec
+++ b/Stagehand.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'Stagehand'
-  s.version          = '2.0'
+  s.version          = '2.0.1'
   s.summary          = 'Modern, type-safe API for building animations on iOS'
   s.homepage         = 'https://github.com/CashApp/Stagehand'
   s.license          = { :type => 'Apache License, Version 2.0', :file => 'LICENSE' }

--- a/Stagehand.podspec
+++ b/Stagehand.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'Stagehand'
-  s.version          = '2.0.1'
+  s.version          = '2.0'
   s.summary          = 'Modern, type-safe API for building animations on iOS'
   s.homepage         = 'https://github.com/CashApp/Stagehand'
   s.license          = { :type => 'Apache License, Version 2.0', :file => 'LICENSE' }

--- a/StagehandTesting.podspec
+++ b/StagehandTesting.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'StagehandTesting'
-  s.version          = '2.0.1'
+  s.version          = '2.0'
   s.summary          = 'Utilities for snapshot testing animations created using the Stagehand framework'
   s.homepage         = 'https://github.com/CashApp/Stagehand'
   s.license          = { :type => 'Apache License, Version 2.0', :file => 'LICENSE' }

--- a/StagehandTesting.podspec
+++ b/StagehandTesting.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'StagehandTesting'
-  s.version          = '2.0'
+  s.version          = '2.0.1'
   s.summary          = 'Utilities for snapshot testing animations created using the Stagehand framework'
   s.homepage         = 'https://github.com/CashApp/Stagehand'
   s.license          = { :type => 'Apache License, Version 2.0', :file => 'LICENSE' }

--- a/StagehandTesting.podspec
+++ b/StagehandTesting.podspec
@@ -19,4 +19,7 @@ Pod::Spec.new do |s|
   s.dependency 'Stagehand', s.version.to_s
 
   s.dependency 'iOSSnapshotTestCase', '~> 6.1'
+
+  s.frameworks = 'XCTest'
+  s.weak_framework = 'XCTest'
 end


### PR DESCRIPTION
This makes the weak framework linking of `XCTest` explicit in the podspec and bumps the version to 2.0.1.