### PR TITLE
Update handling of execution and per-frame execution blocks in child animations

### DIFF
--- a/Example/Stagehand.xcodeproj/project.pbxproj
+++ b/Example/Stagehand.xcodeproj/project.pbxproj
@@ -27,6 +27,7 @@
 		3DA3997C230FCFAC00DE41A0 /* ExecutionBlockViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3DA3997B230FCFAC00DE41A0 /* ExecutionBlockViewController.swift */; };
 		3DA5EB7C2318E64A001DF944 /* CollectionKeyframesViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3DA5EB7B2318E64A001DF944 /* CollectionKeyframesViewController.swift */; };
 		3DB3927D23249D680009E8B3 /* ColorAnimationsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3DB3927C23249D680009E8B3 /* ColorAnimationsViewController.swift */; };
+		3DBFEE422400B2460086D61C /* ChildAnimationProgressViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3DBFEE412400B2460086D61C /* ChildAnimationProgressViewController.swift */; };
 		3DC75494232D82FD00402BD9 /* ChildAnimationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3DC75492232D819700402BD9 /* ChildAnimationTests.swift */; };
 		3DC75497232F6D5500402BD9 /* TestDriver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3DC75496232F6D5500402BD9 /* TestDriver.swift */; };
 		3DEE440A231331DD0057D796 /* AnimationGroupViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3DEE4409231331DD0057D796 /* AnimationGroupViewController.swift */; };
@@ -83,6 +84,7 @@
 		3DA3997B230FCFAC00DE41A0 /* ExecutionBlockViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExecutionBlockViewController.swift; sourceTree = "<group>"; };
 		3DA5EB7B2318E64A001DF944 /* CollectionKeyframesViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CollectionKeyframesViewController.swift; sourceTree = "<group>"; };
 		3DB3927C23249D680009E8B3 /* ColorAnimationsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ColorAnimationsViewController.swift; sourceTree = "<group>"; };
+		3DBFEE412400B2460086D61C /* ChildAnimationProgressViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChildAnimationProgressViewController.swift; sourceTree = "<group>"; };
 		3DC75492232D819700402BD9 /* ChildAnimationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChildAnimationTests.swift; sourceTree = "<group>"; };
 		3DC75496232F6D5500402BD9 /* TestDriver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestDriver.swift; sourceTree = "<group>"; };
 		3DEE4409231331DD0057D796 /* AnimationGroupViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnimationGroupViewController.swift; sourceTree = "<group>"; };
@@ -162,6 +164,7 @@
 				3D75A7C72292910B00743166 /* RelativeAnimationsViewController.swift */,
 				3DB3927C23249D680009E8B3 /* ColorAnimationsViewController.swift */,
 				3D1D304922F007B7003E392C /* ChildAnimationsViewController.swift */,
+				3DBFEE412400B2460086D61C /* ChildAnimationProgressViewController.swift */,
 				3D1D304B22F01136003E392C /* AnimationCurveViewController.swift */,
 				3D8E3D7F22F16C1B00D70FCB /* ChildAnimationsWithCurvesViewController.swift */,
 				3D8E3D8122F17D3B00D70FCB /* AnimationCancelationViewController.swift */,
@@ -555,6 +558,7 @@
 				3D75A7C62292892B00743166 /* SimpleAnimationsViewController.swift in Sources */,
 				3D89F1E222FDEAAC008AC33E /* PropertyAssignmentViewController.swift in Sources */,
 				607FACD81AFB9204008FA782 /* RootViewController.swift in Sources */,
+				3DBFEE422400B2460086D61C /* ChildAnimationProgressViewController.swift in Sources */,
 				3DA5EB7C2318E64A001DF944 /* CollectionKeyframesViewController.swift in Sources */,
 				3DA3997C230FCFAC00DE41A0 /* ExecutionBlockViewController.swift in Sources */,
 				3D2712EE236A17C5001D3B4B /* AnimationQueueViewController.swift in Sources */,

--- a/Example/Stagehand/ChildAnimationProgressViewController.swift
+++ b/Example/Stagehand/ChildAnimationProgressViewController.swift
@@ -1,0 +1,422 @@
+//
+//  Copyright 2020 Square Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Stagehand
+import UIKit
+
+final class ChildAnimationProgressViewController: DemoViewController {
+
+    // MARK: - Life Cycle
+
+    override init() {
+        super.init()
+
+        contentView = mainView
+        contentHeight = 260
+
+        animationRows = [
+            ("Per-Frame in Linear / Linear", { [unowned self] in
+                self.reset()
+
+                let animation = self.makeAnimation(
+                    parentCurve: LinearAnimationCurve(),
+                    childCurve: LinearAnimationCurve(),
+                    trackKeyframes: false
+                )
+
+                self.animationInstance = animation.perform(on: self.element)
+            }),
+            ("Per-Frame in Linear / Ease In Out", { [unowned self] in
+                self.reset()
+
+                let animation = self.makeAnimation(
+                    parentCurve: LinearAnimationCurve(),
+                    childCurve: SinusoidalEaseInEaseOutAnimationCurve(),
+                    trackKeyframes: false
+                )
+
+                self.animationInstance = animation.perform(on: self.element)
+            }),
+            ("Per-Frame in Ease In Out / Ease In Out", { [unowned self] in
+                self.reset()
+
+                let animation = self.makeAnimation(
+                    parentCurve: SinusoidalEaseInEaseOutAnimationCurve(),
+                    childCurve: SinusoidalEaseInEaseOutAnimationCurve(),
+                    trackKeyframes: false
+                )
+
+                self.animationInstance = animation.perform(on: self.element)
+            }),
+            ("Per-Frame in Ease In / Linear", { [unowned self] in
+                self.reset()
+
+                let animation = self.makeAnimation(
+                    parentCurve: ParabolicEaseInAnimationCurve(),
+                    childCurve: LinearAnimationCurve(),
+                    trackKeyframes: false
+                )
+
+                self.animationInstance = animation.perform(on: self.element)
+            }),
+            ("Keyframes in Linear / Linear", { [unowned self] in
+                self.reset()
+
+                let animation = self.makeAnimation(
+                    parentCurve: LinearAnimationCurve(),
+                    childCurve: LinearAnimationCurve(),
+                    trackKeyframes: true
+                )
+
+                self.animationInstance = animation.perform(on: self.element)
+            }),
+            ("Keyframes in Linear / Ease In Out", { [unowned self] in
+                self.reset()
+
+                let animation = self.makeAnimation(
+                    parentCurve: LinearAnimationCurve(),
+                    childCurve: SinusoidalEaseInEaseOutAnimationCurve(),
+                    trackKeyframes: true
+                )
+
+                self.animationInstance = animation.perform(on: self.element)
+            }),
+            ("Keyframes in Ease In Out / Ease In Out", { [unowned self] in
+                self.reset()
+
+                let animation = self.makeAnimation(
+                    parentCurve: SinusoidalEaseInEaseOutAnimationCurve(),
+                    childCurve: SinusoidalEaseInEaseOutAnimationCurve(),
+                    trackKeyframes: true
+                )
+
+                self.animationInstance = animation.perform(on: self.element)
+            }),
+            ("Keyframes in Ease In / Linear", { [unowned self] in
+                self.reset()
+
+                let animation = self.makeAnimation(
+                    parentCurve: ParabolicEaseInAnimationCurve(),
+                    childCurve: LinearAnimationCurve(),
+                    trackKeyframes: true
+                )
+
+                self.animationInstance = animation.perform(on: self.element)
+            }),
+        ]
+    }
+
+    // MARK: - Private Properties
+
+    private weak var animationInstance: AnimationInstance?
+
+    private let mainView: View = .init()
+
+    private let element: Element = .init()
+
+    // MARK: - Private Methods
+
+    private func makeAnimation(
+        parentCurve: AnimationCurve,
+        childCurve: AnimationCurve,
+        trackKeyframes: Bool
+    ) -> Animation<Element> {
+        func relativeTimestamp() -> Double {
+            guard case let .some(.animating(progress)) = self.animationInstance?.status else {
+                return 0
+            }
+            return progress
+        }
+
+        var parentAnimation = Animation<Element>()
+        parentAnimation.curve = parentCurve
+        if trackKeyframes {
+            parentAnimation.addKeyframe(for: \.parentProgress, at: 0, value: 0)
+            parentAnimation.addKeyframe(for: \.parentProgress, at: 1, value: 1)
+            parentAnimation.addPerFrameExecution { context in
+                self.mainView.parentChartView.addPoint(
+                    relativeTimestamp: relativeTimestamp(),
+                    uncurvedProgress: nil,
+                    curvedProgress: context.element.parentProgress
+                )
+            }
+
+        } else {
+            parentAnimation.addPerFrameExecution { context in
+                self.mainView.parentChartView.addPoint(
+                    relativeTimestamp: relativeTimestamp(),
+                    uncurvedProgress: context.uncurvedProgress,
+                    curvedProgress: context.progress
+                )
+            }
+        }
+        parentAnimation.addExecution(
+            onForward: { _ in self.mainView.parentChartView.addExecution(relativeTimestamp: relativeTimestamp()) },
+            at: 0
+        )
+        parentAnimation.addExecution(
+            onForward: { _ in self.mainView.parentChartView.addExecution(relativeTimestamp: relativeTimestamp()) },
+            at: 0.5
+        )
+        parentAnimation.addExecution(
+            onForward: { _ in self.mainView.parentChartView.addExecution(relativeTimestamp: relativeTimestamp()) },
+            at: 1
+        )
+
+        var childAnimation = Animation<Element>()
+        childAnimation.curve = childCurve
+        if trackKeyframes {
+            childAnimation.addKeyframe(for: \.childProgress, at: 0, value: 0)
+            childAnimation.addKeyframe(for: \.childProgress, at: 1, value: 1)
+            childAnimation.addPerFrameExecution { context in
+                self.mainView.childChartView.addPoint(
+                    relativeTimestamp: relativeTimestamp(),
+                    uncurvedProgress: nil,
+                    curvedProgress: context.element.childProgress
+                )
+            }
+
+        } else {
+            childAnimation.addPerFrameExecution { context in
+                self.mainView.childChartView.addPoint(
+                    relativeTimestamp: relativeTimestamp(),
+                    uncurvedProgress: context.uncurvedProgress,
+                    curvedProgress: context.progress
+                )
+            }
+        }
+        childAnimation.addExecution(
+            onForward: { _ in self.mainView.childChartView.addExecution(relativeTimestamp: relativeTimestamp()) },
+            at: 0
+        )
+        childAnimation.addExecution(
+            onForward: { _ in self.mainView.childChartView.addExecution(relativeTimestamp: relativeTimestamp()) },
+            at: 0.5
+        )
+        childAnimation.addExecution(
+            onForward: { _ in self.mainView.childChartView.addExecution(relativeTimestamp: relativeTimestamp()) },
+            at: 1
+        )
+        parentAnimation.addChild(childAnimation, for: \.self, startingAt: 0.25, relativeDuration: 0.5)
+
+        parentAnimation.duration = 4
+        return parentAnimation
+    }
+
+    private func reset() {
+        animationInstance?.cancel()
+
+        mainView.parentChartView.reset()
+        mainView.childChartView.reset()
+    }
+
+}
+
+// MARK: -
+
+private extension ChildAnimationProgressViewController {
+
+    final class View: UIView {
+
+        // MARK: - Life Cycle
+
+        override init(frame: CGRect) {
+            super.init(frame: frame)
+
+            addSubview(parentChartView)
+
+            addSubview(childChartView)
+        }
+
+        @available(*, unavailable)
+        required init?(coder: NSCoder) {
+            fatalError("init(coder:) has not been implemented")
+        }
+
+        // MARK: - Public Properties
+
+        let parentChartView: ChartView = .init()
+
+        let childChartView: ChartView = .init()
+
+        // MARK: - UIView
+
+        override func layoutSubviews() {
+            let chartSize = CGSize(
+                width: bounds.width - 40,
+                height: 100
+            )
+
+            parentChartView.bounds.size = chartSize
+            parentChartView.frame.origin = .init(x: 20, y: 20)
+
+            childChartView.bounds.size = chartSize
+            childChartView.frame.origin = .init(x: 20, y: parentChartView.frame.maxY + 20)
+        }
+
+    }
+
+}
+
+// MARK: -
+
+private extension ChildAnimationProgressViewController {
+
+    final class ChartView: UIView {
+
+        // MARK: - Life Cycle
+
+        override init(frame: CGRect) {
+            super.init(frame: frame)
+
+            gridLayer.fillColor = nil
+            gridLayer.lineWidth = 1
+            gridLayer.strokeColor = UIColor(white: 0.9, alpha: 1).cgColor
+            layer.addSublayer(gridLayer)
+
+            uncurvedProgressLayer.fillColor = nil
+            uncurvedProgressLayer.lineWidth = 1.5
+            uncurvedProgressLayer.strokeColor = UIColor(white: 0.7, alpha: 1).cgColor
+            layer.addSublayer(uncurvedProgressLayer)
+
+            curvedProgressLayer.fillColor = nil
+            curvedProgressLayer.lineWidth = 1.5
+            curvedProgressLayer.strokeColor = UIColor(white: 0.3, alpha: 1).cgColor
+            layer.addSublayer(curvedProgressLayer)
+
+            executionBlocksLayer.fillColor = nil
+            executionBlocksLayer.lineWidth = 1.5
+            executionBlocksLayer.strokeColor = UIColor.blue.cgColor
+            layer.addSublayer(executionBlocksLayer)
+        }
+
+        @available(*, unavailable)
+        required init?(coder: NSCoder) {
+            fatalError("init(coder:) has not been implemented")
+        }
+
+        // MARK: - Private Properties
+
+        private let gridLayer: CAShapeLayer = .init()
+
+        private let uncurvedProgressLayer: CAShapeLayer = .init()
+        private var uncurvedProgressPath: UIBezierPath = .init()
+
+        private let curvedProgressLayer: CAShapeLayer = .init()
+        private var curvedProgressPath: UIBezierPath = .init()
+
+        private let executionBlocksLayer: CAShapeLayer = .init()
+        private var executionBlocksPath: UIBezierPath = .init()
+
+        // MARK: - UIView
+
+        override func layoutSubviews() {
+            gridLayer.frame = bounds
+            updateGrid()
+
+            uncurvedProgressLayer.frame = bounds
+            curvedProgressLayer.frame = bounds
+            executionBlocksLayer.frame = bounds
+        }
+
+        // MARK: - Public Methods
+
+        func addPoint(relativeTimestamp: Double, uncurvedProgress: Double?, curvedProgress: Double) {
+            if let uncurvedProgress = uncurvedProgress {
+                let uncurvedProgressPoint = CGPoint(
+                    x: CGFloat(relativeTimestamp) * uncurvedProgressLayer.bounds.width,
+                    y: CGFloat(1 - uncurvedProgress) * uncurvedProgressLayer.bounds.height
+                )
+                if uncurvedProgressPath.isEmpty {
+                    uncurvedProgressPath.move(to: uncurvedProgressPoint)
+                } else {
+                    uncurvedProgressPath.addLine(to: uncurvedProgressPoint)
+                }
+                uncurvedProgressLayer.path = uncurvedProgressPath.cgPath
+            }
+
+            let curvedProgressPoint = CGPoint(
+                x: CGFloat(relativeTimestamp) * curvedProgressLayer.bounds.width,
+                y: CGFloat(1 - curvedProgress) * curvedProgressLayer.bounds.height
+            )
+            if curvedProgressPath.isEmpty {
+                curvedProgressPath.move(to: curvedProgressPoint)
+            } else {
+                curvedProgressPath.addLine(to: curvedProgressPoint)
+            }
+            curvedProgressLayer.path = curvedProgressPath.cgPath
+        }
+
+        func addExecution(relativeTimestamp: Double) {
+            let positionX = CGFloat(relativeTimestamp) * executionBlocksLayer.bounds.width
+            executionBlocksPath.move(to: .init(x: positionX, y: 0))
+            executionBlocksPath.addLine(to: .init(x: positionX, y: executionBlocksLayer.bounds.height))
+            executionBlocksLayer.path = executionBlocksPath.cgPath
+        }
+
+        func reset() {
+            uncurvedProgressPath = .init()
+            uncurvedProgressLayer.path = uncurvedProgressPath.cgPath
+
+            curvedProgressPath = .init()
+            curvedProgressLayer.path = curvedProgressPath.cgPath
+
+            executionBlocksPath = .init()
+            executionBlocksLayer.path = executionBlocksPath.cgPath
+        }
+
+        // MARK: - Private Methods
+
+        private func updateGrid() {
+            let gridPath = UIBezierPath()
+
+            let horizontalDivisions = 12
+            let verticalDivisions = 4
+            let cellSize = CGSize(
+                width: gridLayer.bounds.width / CGFloat(horizontalDivisions),
+                height: gridLayer.bounds.height / CGFloat(verticalDivisions)
+            )
+
+            for row in 0...verticalDivisions {
+                gridPath.move(to: CGPoint(x: 0, y: cellSize.height * CGFloat(row)))
+                gridPath.addLine(to: CGPoint(x: gridLayer.bounds.width, y: cellSize.height * CGFloat(row)))
+            }
+
+            for column in 0...horizontalDivisions {
+                gridPath.move(to: CGPoint(x: cellSize.width * CGFloat(column), y: 0))
+                gridPath.addLine(to: CGPoint(x: cellSize.width * CGFloat(column), y: gridLayer.bounds.height))
+            }
+
+            gridLayer.path = gridPath.cgPath
+        }
+
+    }
+
+}
+
+// MARK: -
+
+private extension ChildAnimationProgressViewController {
+
+    final class Element {
+
+        var parentProgress: Double = -1
+
+        var childProgress: Double = -1
+
+    }
+
+}

--- a/Example/Stagehand/DemoViewController.swift
+++ b/Example/Stagehand/DemoViewController.swift
@@ -103,6 +103,7 @@ extension DemoViewController: UITableViewDataSource, UITableViewDelegate {
     func tableView(_ tableView: UITableView, willDisplay cell: UITableViewCell, forRowAt indexPath: IndexPath) {
         let row = animationRows[indexPath.row]
         cell.textLabel?.text = row.name
+        cell.textLabel?.adjustsFontSizeToFitWidth = true
     }
 
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {

--- a/Example/Stagehand/RootViewController.swift
+++ b/Example/Stagehand/RootViewController.swift
@@ -40,6 +40,7 @@ final class RootViewController: UITableViewController {
         ("Child Animations", { ChildAnimationsViewController() }),
         ("Animation Curves", { AnimationCurveViewController() }),
         ("Child Animations with Curves", { ChildAnimationsWithCurvesViewController() }),
+        ("Child Animation Progress", { ChildAnimationProgressViewController() }),
         ("Animation Cancellation", { AnimationCancelationViewController() }),
         ("Property Assignments", { PropertyAssignmentViewController() }),
         ("Repeating Animations", { RepeatingAnimationsViewController() }),

--- a/Sources/Stagehand/Animation/Animation.swift
+++ b/Sources/Stagehand/Animation/Animation.swift
@@ -396,10 +396,9 @@ public struct Animation<ElementType: AnyObject> {
             contentsOf: childAnimation.executionBlocks.map { childExecutionBlock in
                 // Adjust the relative timestamp for the child's animation curve.
                 let relativeTimestamp = relativeStartTimestamp + (childExecutionBlock.relativeTimestamp * relativeDuration)
-                let adjustedRelativeTimestamp = childAnimation.curve.adjustedProgress(for: relativeTimestamp)
 
                 return ExecutionBlock(
-                    relativeTimestamp: adjustedRelativeTimestamp,
+                    relativeTimestamp: relativeTimestamp,
                     forwardBlock: { element in
                         childExecutionBlock.forwardBlock(element[keyPath: subelement])
                     },
@@ -414,18 +413,18 @@ public struct Animation<ElementType: AnyObject> {
         perFrameExecutionBlocks.append(
             contentsOf: childAnimation.perFrameExecutionBlocks.map { childExecutionBlock in
                 return { context in
-                    guard context.uncurvedProgress >= relativeStartTimestamp else {
+                    guard context.progress >= relativeStartTimestamp else {
                         // The child animation hasn't started yet.
                         return
                     }
 
-                    guard context.uncurvedProgress <= (relativeStartTimestamp + relativeDuration) else {
+                    guard context.progress <= (relativeStartTimestamp + relativeDuration) else {
                         // The child animation already ended.
                         return
                     }
 
                     // The uncurved progress of the child animation is based on the curved progress of the parent.
-                    let uncurvedProgress = context.progress
+                    let uncurvedProgress = (context.progress - relativeStartTimestamp) / relativeDuration
 
                     childExecutionBlock(
                         .init(

--- a/Sources/Stagehand/AnimationInstance/AnimationInstance.swift
+++ b/Sources/Stagehand/AnimationInstance/AnimationInstance.swift
@@ -210,6 +210,10 @@ public final class AnimationInstance {
         _ fromInclusivity: Inclusivity,
         to endingRelativeTimestamp: Double
     ) {
+        // Apply the animation curve to the start/end timestamps.
+        let startingRelativeTimestamp = animationCurve.adjustedProgress(for: startingRelativeTimestamp)
+        let endingRelativeTimestamp = animationCurve.adjustedProgress(for: endingRelativeTimestamp)
+
         if endingRelativeTimestamp >= startingRelativeTimestamp {
             // Iterate forward through the execution blocks.
             for (index, executionBlock) in sortedExecutionBlocks.enumerated() {
@@ -243,6 +247,8 @@ public final class AnimationInstance {
             return
         }
 
+        status = .animating(progress: relativeTimestamp)
+
         // If we skipped any keyframes since the last frame we rendered, render them now. If we don't do this, we might
         // skip rendering the last keyframe of a child animation, leaving the properties of that animation in their
         // value just shy of the value specified by the final keyframe.
@@ -275,8 +281,6 @@ public final class AnimationInstance {
         renderer.renderFrame(at: relativeTimestamp)
 
         perFrameExecutionBlocks.forEach { $0(relativeTimestamp) }
-
-        status = .animating(progress: relativeTimestamp)
 
         lastRenderedFrameRelativeTimestamp = relativeTimestamp
     }


### PR DESCRIPTION
This makes a few updates to the handling of execution blocks and per-frame execution blocks in child animations. Previously, per-frame execution blocks in child animations were only executed during the duration where the child was added, but the progress values in the context corresponded to that of the parent animation (#14). This breaks down the ability for child animations to independently reason about phases of the animation without context on the parent animation.

A similar problem existed with execution blocks, where the relative timestamp at which the block is executed was relative to the uncurved progress. This broke down when a child animation was being collapsed into the parent.

In order to address these issues, the following changes were made:

* Per-frame execution blocks are executed based on the curved progress of the parent animation, while the context shows the progress of the child animation.

* The timestamp for execution blocks is determined based off of the curved progress of the animation.

* The state of the animation instance is updated before the frame is rendered, to enable per-frame execution blocks to check the progress of the overall parent animation.

There is an argument to be made for basing the execution blocks off of the uncurved progress, but this can be achieved by wrapping the curved animation in a linear animation and adding the execution blocks to that parent.

Resolves #14.