### PR TITLE
Delay calling completion handlers until final frame is drawn to screen

### DIFF
--- a/Example/Unit Tests/DisplayLinkDriverTests.swift
+++ b/Example/Unit Tests/DisplayLinkDriverTests.swift
@@ -557,10 +557,10 @@ final class DisplayLinkDriverTests: XCTestCase {
     }
 
     func testCallsCompletion() {
-        let expectation = self.expectation(description: "calls completion")
+        var calledCompletion: Bool = false
         let completion: (Bool) -> Void = { success in
             XCTAssertTrue(success)
-            expectation.fulfill()
+            calledCompletion = true
         }
 
         let displayLink = TestDisplayLink()
@@ -581,9 +581,18 @@ final class DisplayLinkDriverTests: XCTestCase {
 
         driver.start(timeFactory: Factory.timeFactory)
 
+        // When the display link hits the end, the final frame should be rendered, but the completion should not yet be
+        // called. The display link will be left running so that there will be one more call.
         displayLink.simulateRunLoop(at: 1)
 
-        waitForExpectations(timeout: 1, handler: nil)
+        XCTAssertFalse(calledCompletion)
+        XCTAssertFalse(displayLink.wasInvalidated)
+
+        // On the final call, the driver should call the completion and invalidate the display link.
+        displayLink.simulateRunLoop(at: 1.1)
+
+        XCTAssertTrue(calledCompletion)
+        XCTAssertTrue(displayLink.wasInvalidated)
     }
 
     // MARK: - Tests - Cancellation
@@ -983,12 +992,14 @@ private final class TestDisplayLink: DisplayLinkDriverDisplayLink {
 
     private(set) var timestamp: CFTimeInterval = 0
 
+    private(set) var wasInvalidated: Bool = false
+
     func add(to runloop: RunLoop, forMode mode: RunLoop.Mode) {
         // No-op.
     }
 
     func invalidate() {
-        // No-op.
+        wasInvalidated = true
     }
 
     // MARK: - Private  Properties

--- a/Example/Unit Tests/DisplayLinkDriverTests.swift
+++ b/Example/Unit Tests/DisplayLinkDriverTests.swift
@@ -557,7 +557,7 @@ final class DisplayLinkDriverTests: XCTestCase {
     }
 
     func testCallsCompletion() {
-        var calledCompletion: Bool = false
+        var calledCompletion = false
         let completion: (Bool) -> Void = { success in
             XCTAssertTrue(success)
             calledCompletion = true
@@ -992,7 +992,7 @@ private final class TestDisplayLink: DisplayLinkDriverDisplayLink {
 
     private(set) var timestamp: CFTimeInterval = 0
 
-    private(set) var wasInvalidated: Bool = false
+    private(set) var wasInvalidated = false
 
     func add(to runloop: RunLoop, forMode mode: RunLoop.Mode) {
         // No-op.

--- a/Sources/Stagehand/Driver/DisplayLinkDriver.swift
+++ b/Sources/Stagehand/Driver/DisplayLinkDriver.swift
@@ -47,6 +47,14 @@ internal final class DisplayLinkDriver: Driver {
 
     }
 
+    private enum Status {
+
+        case active
+
+        case completed(success: Bool)
+
+    }
+
     // MARK: - Private Properties
 
     private let delay: TimeInterval
@@ -62,6 +70,8 @@ internal final class DisplayLinkDriver: Driver {
     private var startTime: TimeInterval?
 
     private var lastRenderedFrame: Frame?
+
+    private var status: Status = .active
 
     // MARK: - Private Computed Properties
 
@@ -154,6 +164,22 @@ internal final class DisplayLinkDriver: Driver {
     }
 
     @objc func renderCurrentFrame() {
+        switch status {
+        case .active:
+            break
+
+        case let .completed(success: success):
+            displayLink?.invalidate()
+            displayLink = nil
+
+            animationInstance = nil
+
+            completions.forEach { $0(success) }
+            completions = []
+
+            return
+        }
+
         guard let displayLink = displayLink, let startTime = startTime else {
             return
         }
@@ -265,12 +291,11 @@ internal final class DisplayLinkDriver: Driver {
     // MARK: - Private Methods
 
     private func complete(success: Bool) {
-        displayLink?.invalidate()
-        displayLink = nil
-
-        animationInstance = nil
-
-        completions.forEach { $0(success) }
+        // Set the status to `completed` in order to stop rendering frames. We'll call the completion handlers and
+        // invalidate the display link on the next display loop pass. This ensures that the final frame is drawn to
+        // the screen before the completion handlers are called, in case they do work that would otherwise casue a
+        // delay in drawing.
+        status = .completed(success: success)
     }
 
 }

--- a/Sources/Stagehand/Driver/DisplayLinkDriver.swift
+++ b/Sources/Stagehand/Driver/DisplayLinkDriver.swift
@@ -293,7 +293,7 @@ internal final class DisplayLinkDriver: Driver {
     private func complete(success: Bool) {
         // Set the status to `completed` in order to stop rendering frames. We'll call the completion handlers and
         // invalidate the display link on the next display loop pass. This ensures that the final frame is drawn to
-        // the screen before the completion handlers are called, in case they do work that would otherwise casue a
+        // the screen before the completion handlers are called, in case they do work that would otherwise cause a
         // delay in drawing.
         status = .completed(success: success)
     }


### PR DESCRIPTION
Previously, completion handlers for an animation were called in the same display loop pass as the rendering of the final frame. If the completion handlers did any significant amount of work, this could result in delayed drawing of the final frame.

This moves the call to the completion handlers to happen on the next display loop pass after the final frame is rendering, to ensure that the final frame is drawn to screen without delay.

Resolves #21.