### PR TITLE
Enable adding child animations for immutable subelements

### DIFF
--- a/Example/Stagehand/ChildAnimationsViewController.swift
+++ b/Example/Stagehand/ChildAnimationsViewController.swift
@@ -158,12 +158,9 @@ extension ChildAnimationsViewController {
 
         // MARK: - Public Properties
 
-        // Due to a limitation in how Swift KeyPaths are appended, these properties need to be mutable since they will
-        // be used for a child animation.
+        let leftView: UIView = .init()
 
-        var leftView: UIView = .init()
-
-        var rightView: UIView = .init()
+        let rightView: UIView = .init()
 
         // MARK: - UIView
 


### PR DESCRIPTION
This enabled adding child animations for immutable reference type subelements. There is a bit of unsafe type conversion added to the internals of the framework in order to support this, but the public API remains type-safe given the `AnyObject` restriction.

Resolves #23.