### PR TITLE
Fix execution of execution blocks and property assignments in curved animations

### DIFF
--- a/Example/Stagehand.xcodeproj/project.pbxproj
+++ b/Example/Stagehand.xcodeproj/project.pbxproj
@@ -20,6 +20,7 @@
 		3D7D500023011D4400A468A7 /* AnimationInstanceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D7D4FFE23011C4600A468A7 /* AnimationInstanceTests.swift */; };
 		3D7E79AB239FC1F8008BF8FF /* DisplayLinkDriverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D7E79AA239FC1F8008BF8FF /* DisplayLinkDriverTests.swift */; };
 		3D875F002323542500670803 /* PerformanceBenchmarkViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D875EFF2323542500670803 /* PerformanceBenchmarkViewController.swift */; };
+		3D89890F2450DEB3006824FC /* ExecutorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D89890E2450DEB3006824FC /* ExecutorTests.swift */; };
 		3D89F1E222FDEAAC008AC33E /* PropertyAssignmentViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D89F1E122FDEAAC008AC33E /* PropertyAssignmentViewController.swift */; };
 		3D8E3D8022F16C1B00D70FCB /* ChildAnimationsWithCurvesViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D8E3D7F22F16C1B00D70FCB /* ChildAnimationsWithCurvesViewController.swift */; };
 		3D8E3D8222F17D3B00D70FCB /* AnimationCancelationViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D8E3D8122F17D3B00D70FCB /* AnimationCancelationViewController.swift */; };
@@ -77,6 +78,7 @@
 		3D7D4FFE23011C4600A468A7 /* AnimationInstanceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnimationInstanceTests.swift; sourceTree = "<group>"; };
 		3D7E79AA239FC1F8008BF8FF /* DisplayLinkDriverTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DisplayLinkDriverTests.swift; sourceTree = "<group>"; };
 		3D875EFF2323542500670803 /* PerformanceBenchmarkViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PerformanceBenchmarkViewController.swift; sourceTree = "<group>"; };
+		3D89890E2450DEB3006824FC /* ExecutorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExecutorTests.swift; sourceTree = "<group>"; };
 		3D89F1E122FDEAAC008AC33E /* PropertyAssignmentViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PropertyAssignmentViewController.swift; sourceTree = "<group>"; };
 		3D8E3D7F22F16C1B00D70FCB /* ChildAnimationsWithCurvesViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChildAnimationsWithCurvesViewController.swift; sourceTree = "<group>"; };
 		3D8E3D8122F17D3B00D70FCB /* AnimationCancelationViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnimationCancelationViewController.swift; sourceTree = "<group>"; };
@@ -263,6 +265,7 @@
 			isa = PBXGroup;
 			children = (
 				3D7D4FFE23011C4600A468A7 /* AnimationInstanceTests.swift */,
+				3D89890E2450DEB3006824FC /* ExecutorTests.swift */,
 				3D32EF49234058C7001144B3 /* AnimationOptimizationTests.swift */,
 				607FACEB1AFB9204008FA782 /* AnimationSnapshotTests.swift */,
 				3DC75492232D819700402BD9 /* ChildAnimationTests.swift */,
@@ -581,6 +584,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				3D89890F2450DEB3006824FC /* ExecutorTests.swift in Sources */,
 				3DC75497232F6D5500402BD9 /* TestDriver.swift in Sources */,
 				607FACEC1AFB9204008FA782 /* AnimationSnapshotTests.swift in Sources */,
 				3D7D500023011D4400A468A7 /* AnimationInstanceTests.swift in Sources */,

--- a/Example/Unit Tests/DisplayLinkDriverTests.swift
+++ b/Example/Unit Tests/DisplayLinkDriverTests.swift
@@ -954,7 +954,7 @@ private final class TestAnimationInstance: DrivenAnimationInstance {
 
     // MARK: - Public Properties
 
-    private(set) var executedBlockSequences: [(Double, AnimationInstance.Inclusivity, Double)] = []
+    private(set) var executedBlockSequences: [(Double, Executor.Inclusivity, Double)] = []
 
     private(set) var renderedFrames: [Double] = []
 
@@ -970,7 +970,7 @@ private final class TestAnimationInstance: DrivenAnimationInstance {
 
     // MARK: - DrivenAnimationInstance
 
-    func executeBlocks(from startingRelativeTimestamp: Double, _ fromInclusivity: AnimationInstance.Inclusivity, to endingRelativeTimestamp: Double) {
+    func executeBlocks(from startingRelativeTimestamp: Double, _ fromInclusivity: Executor.Inclusivity, to endingRelativeTimestamp: Double) {
         executedBlockSequences.append((startingRelativeTimestamp, fromInclusivity, endingRelativeTimestamp))
     }
 

--- a/Example/Unit Tests/ExecutorTests.swift
+++ b/Example/Unit Tests/ExecutorTests.swift
@@ -1,0 +1,509 @@
+//
+//  Copyright 2020 Square Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import XCTest
+
+@testable import Stagehand
+
+final class ExecutorTests: XCTestCase {
+
+    // MARK: - Tests - Property Assignment
+
+    func testPropertyAssignment() {
+        let initialValue = "A"
+        let midpointValue = "B"
+        let finalValue = "C"
+
+        let element = Element(property: initialValue)
+
+        var animation = Animation<Element>()
+        animation.addAssignment(for: \.property, at: 0.5, value: midpointValue)
+        animation.addAssignment(for: \.property, at: 1, value: finalValue)
+
+        let executor = Executor(animation: animation, element: element)
+
+        executor.executeBlocks(from: 0, .inclusive, to: 0.49)
+        XCTAssertEqual(element.property, initialValue)
+
+        executor.executeBlocks(from: 0.49, .exclusive, to: 0.51)
+        XCTAssertEqual(element.property, midpointValue)
+
+        executor.executeBlocks(from: 0.51, .exclusive, to: 0.99)
+        XCTAssertEqual(element.property, midpointValue)
+
+        executor.executeBlocks(from: 0.99, .exclusive, to: 1)
+        XCTAssertEqual(element.property, finalValue)
+
+        executor.executeBlocks(from: 1, .inclusive, to: 0.99)
+        XCTAssertEqual(element.property, midpointValue)
+
+        executor.executeBlocks(from: 0.99, .exclusive, to: 0.51)
+        XCTAssertEqual(element.property, midpointValue)
+
+        executor.executeBlocks(from: 0.51, .exclusive, to: 0.49)
+        XCTAssertEqual(element.property, initialValue)
+
+        executor.executeBlocks(from: 0.49, .exclusive, to: 0)
+        XCTAssertEqual(element.property, initialValue)
+    }
+
+    func testPropertyAssignmentOnExactFrame() {
+        let initialValue = "A"
+        let midpointValue = "B"
+        let finalValue = "C"
+
+        let element = Element(property: initialValue)
+
+        var animation = Animation<Element>()
+        animation.addAssignment(for: \.property, at: 0.5, value: midpointValue)
+        animation.addAssignment(for: \.property, at: 1, value: finalValue)
+
+        let executor = Executor(animation: animation, element: element)
+
+        executor.executeBlocks(from: 0, .inclusive, to: 0.49)
+        XCTAssertEqual(element.property, initialValue)
+
+        // Ending on the assignment's timestamp exactly should still trigger the assignment.
+        executor.executeBlocks(from: 0.49, .exclusive, to: 0.5)
+        XCTAssertEqual(element.property, midpointValue)
+    }
+
+    func testPropertyAssignmentSkippingFrames() {
+        let initialValue = "A"
+        let midpointValue = "B"
+        let finalValue = "C"
+
+        let element = Element(property: initialValue)
+
+        var animation = Animation<Element>()
+        animation.addAssignment(for: \.property, at: 0.5, value: midpointValue)
+        animation.addAssignment(for: \.property, at: 1, value: finalValue)
+
+        let executor = Executor(animation: animation, element: element)
+
+        executor.executeBlocks(from: 0, .inclusive, to: 0.49)
+        XCTAssertEqual(element.property, initialValue)
+
+        // Jumping from 0.49 to 1 should execute the assignments at 0.5 and 1.
+        executor.executeBlocks(from: 0.49, .exclusive, to: 1)
+        XCTAssertEqual(element.property, finalValue)
+
+        // We should still have the inner midpoint value stored for the reverse cycle.
+        executor.executeBlocks(from: 1, .inclusive, to: 0.99)
+        XCTAssertEqual(element.property, midpointValue)
+
+        executor.executeBlocks(from: 0.99, .exclusive, to: 0.51)
+        XCTAssertEqual(element.property, midpointValue)
+
+        executor.executeBlocks(from: 0.51, .exclusive, to: 0.49)
+        XCTAssertEqual(element.property, initialValue)
+
+        executor.executeBlocks(from: 0.49, .exclusive, to: 0)
+        XCTAssertEqual(element.property, initialValue)
+    }
+
+    func testPropertyAssignmentInChildAnimation() {
+        let initialValue = "-"
+        let startValue = "A"
+        let midpointValue = "B"
+        let finalValue = "C"
+
+        let element = Element(property: initialValue)
+
+        var childAnimation = Animation<Element>()
+        childAnimation.addAssignment(for: \.property, at: 0, value: startValue)
+        childAnimation.addAssignment(for: \.property, at: 0.5, value: midpointValue)
+        childAnimation.addAssignment(for: \.property, at: 1, value: finalValue)
+
+        var parentAnimation = Animation<Element>()
+        parentAnimation.addChild(childAnimation, for: \.self, startingAt: 0.3, relativeDuration: 0.6)
+
+        let executor = Executor(animation: parentAnimation, element: element)
+
+        executor.executeBlocks(from: 0, .inclusive, to: 0.29)
+        XCTAssertEqual(element.property, initialValue)
+
+        executor.executeBlocks(from: 0.29, .exclusive, to: 0.31)
+        XCTAssertEqual(element.property, startValue)
+
+        executor.executeBlocks(from: 0.31, .exclusive, to: 0.59)
+        XCTAssertEqual(element.property, startValue)
+
+        executor.executeBlocks(from: 0.59, .exclusive, to: 0.61)
+        XCTAssertEqual(element.property, midpointValue)
+
+        executor.executeBlocks(from: 0.61, .exclusive, to: 0.89)
+        XCTAssertEqual(element.property, midpointValue)
+
+        executor.executeBlocks(from: 0.89, .exclusive, to: 0.91)
+        XCTAssertEqual(element.property, finalValue)
+
+        executor.executeBlocks(from: 0.91, .exclusive, to: 1)
+        executor.executeBlocks(from: 1, .inclusive, to: 0.91)
+        XCTAssertEqual(element.property, finalValue)
+
+        executor.executeBlocks(from: 0.91, .exclusive, to: 0.89)
+        XCTAssertEqual(element.property, midpointValue)
+
+        executor.executeBlocks(from: 0.89, .exclusive, to: 0.61)
+        XCTAssertEqual(element.property, midpointValue)
+
+        executor.executeBlocks(from: 0.61, .exclusive, to: 0.59)
+        XCTAssertEqual(element.property, startValue)
+
+        executor.executeBlocks(from: 0.59, .exclusive, to: 0.31)
+        XCTAssertEqual(element.property, startValue)
+
+        executor.executeBlocks(from: 0.31, .exclusive, to: 0.29)
+        XCTAssertEqual(element.property, initialValue)
+    }
+
+    func testPropertyAssignmentWithCurvedAnimation() {
+        let initialValue = "A"
+        let midpointValue = "B"
+        let finalValue = "C"
+
+        let element = Element(property: initialValue)
+
+        var animation = Animation<Element>()
+        animation.addAssignment(for: \.property, at: 0.5, value: midpointValue)
+        animation.addAssignment(for: \.property, at: 1, value: finalValue)
+
+        // Apply a parabolic easing curve. We can calculate the uncurved timestamp at which the assignment should occur
+        // by taking the square root of the curved timestamp.
+        animation.curve = ParabolicEaseInAnimationCurve()
+
+        let executor = Executor(animation: animation, element: element)
+
+        executor.executeBlocks(from: 0, .inclusive, to: 0.7)
+        XCTAssertEqual(element.property, initialValue)
+
+        executor.executeBlocks(from: 0.7, .exclusive, to: 0.71)
+        XCTAssertEqual(element.property, midpointValue)
+
+        executor.executeBlocks(from: 0.71, .exclusive, to: 0.99)
+        XCTAssertEqual(element.property, midpointValue)
+
+        executor.executeBlocks(from: 0.99, .exclusive, to: 1)
+        XCTAssertEqual(element.property, finalValue)
+
+        executor.executeBlocks(from: 1, .inclusive, to: 0.99)
+        XCTAssertEqual(element.property, midpointValue)
+
+        executor.executeBlocks(from: 0.99, .exclusive, to: 0.71)
+        XCTAssertEqual(element.property, midpointValue)
+
+        executor.executeBlocks(from: 0.71, .exclusive, to: 0.7)
+        XCTAssertEqual(element.property, initialValue)
+
+        executor.executeBlocks(from: 0.7, .exclusive, to: 0)
+        XCTAssertEqual(element.property, initialValue)
+    }
+
+    func testPropertyAssignmentInCurvedChildAnimation() {
+        let initialValue = "-"
+        let startValue = "A"
+        let midpointValue = "B"
+        let finalValue = "C"
+
+        let element = Element(property: initialValue)
+
+        var childAnimation = Animation<Element>()
+        childAnimation.addAssignment(for: \.property, at: 0, value: startValue)
+        childAnimation.addAssignment(for: \.property, at: 0.5, value: midpointValue)
+        childAnimation.addAssignment(for: \.property, at: 1, value: finalValue)
+
+        // Apply a parabolic easing curve. We can calculate the uncurved timestamp at which the assignment should occur
+        // by taking the square root of the curved timestamp.
+        childAnimation.curve = ParabolicEaseInAnimationCurve()
+
+        var parentAnimation = Animation<Element>()
+        parentAnimation.addChild(childAnimation, for: \.self, startingAt: 0.3, relativeDuration: 0.6)
+
+        let executor = Executor(animation: parentAnimation, element: element)
+
+        executor.executeBlocks(from: 0, .inclusive, to: 0.29)
+        XCTAssertEqual(element.property, initialValue)
+
+        executor.executeBlocks(from: 0.29, .exclusive, to: 0.31)
+        XCTAssertEqual(element.property, startValue)
+
+        executor.executeBlocks(from: 0.31, .exclusive, to: 0.72)
+        XCTAssertEqual(element.property, startValue)
+
+        executor.executeBlocks(from: 0.72, .exclusive, to: 0.73)
+        XCTAssertEqual(element.property, midpointValue)
+
+        executor.executeBlocks(from: 0.73, .exclusive, to: 0.89)
+        XCTAssertEqual(element.property, midpointValue)
+
+        executor.executeBlocks(from: 0.89, .exclusive, to: 0.91)
+        XCTAssertEqual(element.property, finalValue)
+
+        executor.executeBlocks(from: 0.91, .exclusive, to: 1)
+        executor.executeBlocks(from: 1, .inclusive, to: 0.91)
+        XCTAssertEqual(element.property, finalValue)
+
+        executor.executeBlocks(from: 0.91, .exclusive, to: 0.89)
+        XCTAssertEqual(element.property, midpointValue)
+
+        executor.executeBlocks(from: 0.89, .exclusive, to: 0.73)
+        XCTAssertEqual(element.property, midpointValue)
+
+        executor.executeBlocks(from: 0.73, .exclusive, to: 0.72)
+        XCTAssertEqual(element.property, startValue)
+
+        executor.executeBlocks(from: 0.72, .exclusive, to: 0.31)
+        XCTAssertEqual(element.property, startValue)
+
+        executor.executeBlocks(from: 0.31, .exclusive, to: 0.29)
+        XCTAssertEqual(element.property, initialValue)
+    }
+
+    // MARK: - Tests - Execution Blocks
+
+    func testExecutionBlocks() {
+        var executedBlocks: [String] = []
+
+        var animation = Animation<Element>()
+        animation.addExecution(
+            onForward: { _ in executedBlocks.append("A") },
+            onReverse: { _ in executedBlocks.append("A'") },
+            at: 0
+        )
+        animation.addExecution(
+            onForward: { _ in executedBlocks.append("C") },
+            onReverse: { _ in executedBlocks.append("C'") },
+            at: 0.75
+        )
+        animation.addExecution(
+            onForward: { _ in executedBlocks.append("B") },
+            onReverse: { _ in executedBlocks.append("B'") },
+            at: 0.5
+        )
+
+        let element = Element()
+        let executor = Executor(animation: animation, element: element)
+
+        // Test that the starting timestamp is inclusive when specified as such.
+        executor.executeBlocks(from: 0, .inclusive, to: 0.25)
+        XCTAssertEqual(executedBlocks, ["A"])
+
+        // Test that the ending timestamp is inclusive.
+        executedBlocks = []
+        executor.executeBlocks(from: 0.25, .exclusive, to: 0.5)
+        XCTAssertEqual(executedBlocks, ["B"])
+
+        // Test that the execution blocks are executed in the correct order.
+        executedBlocks = []
+        executor.executeBlocks(from: 0, .inclusive, to: 1)
+        XCTAssertEqual(executedBlocks, ["A", "B", "C"])
+
+        // Test that excluding the starting timestamp doesn't include a block at that timestamp.
+        executedBlocks = []
+        executor.executeBlocks(from: 0, .exclusive, to: 1)
+        XCTAssertEqual(executedBlocks, ["B", "C"])
+
+        // Test that the ending timestamp is inclusive when running in reverse.
+        executedBlocks = []
+        executor.executeBlocks(from: 1, .exclusive, to: 0.75)
+        XCTAssertEqual(executedBlocks, ["C'"])
+
+        // Test that the starting timestamp is inclusive when specified as such.
+        executedBlocks = []
+        executor.executeBlocks(from: 0.75, .inclusive, to: 0.5)
+        XCTAssertEqual(executedBlocks, ["C'", "B'"])
+
+        // Test that the starting timestamp is exclusive when specified as such.
+        executedBlocks = []
+        executor.executeBlocks(from: 0.75, .exclusive, to: 0.5)
+        XCTAssertEqual(executedBlocks, ["B'"])
+
+        // Test that the blocks are ordered correctly when running in reverse.
+        executedBlocks = []
+        executor.executeBlocks(from: 1, .inclusive, to: 0)
+        XCTAssertEqual(executedBlocks, ["C'", "B'", "A'"])
+    }
+
+    func testExecutionBlocksInChildAnimation() {
+        var executedBlocks: [String] = []
+
+        var childAnimation = Animation<Element>()
+        childAnimation.addExecution(
+            onForward: { _ in executedBlocks.append("A") },
+            onReverse: { _ in executedBlocks.append("A'") },
+            at: 0
+        )
+        childAnimation.addExecution(
+            onForward: { _ in executedBlocks.append("C") },
+            onReverse: { _ in executedBlocks.append("C'") },
+            at: 0.75
+        )
+        childAnimation.addExecution(
+            onForward: { _ in executedBlocks.append("B") },
+            onReverse: { _ in executedBlocks.append("B'") },
+            at: 0.5
+        )
+
+        var parentAnimation = Animation<Element>()
+        parentAnimation.addChild(childAnimation, for: \.self, startingAt: 0.3, relativeDuration: 0.6)
+
+        let element = Element()
+        let executor = Executor(animation: parentAnimation, element: element)
+
+        // Test that blocks aren't executed before the child animation begins.
+        executor.executeBlocks(from: 0, .inclusive, to: 0.29)
+        XCTAssertEqual(executedBlocks, [])
+
+        executedBlocks = []
+        executor.executeBlocks(from: 0.29, .exclusive, to: 0.31)
+        XCTAssertEqual(executedBlocks, ["A"])
+
+        executedBlocks = []
+        executor.executeBlocks(from: 0.31, .exclusive, to: 0.59)
+        XCTAssertEqual(executedBlocks, [])
+
+        executedBlocks = []
+        executor.executeBlocks(from: 0.59, .inclusive, to: 0.61)
+        XCTAssertEqual(executedBlocks, ["B"])
+
+        executedBlocks = []
+        executor.executeBlocks(from: 0.61, .inclusive, to: 0.74)
+        XCTAssertEqual(executedBlocks, [])
+
+        executedBlocks = []
+        executor.executeBlocks(from: 0.74, .inclusive, to: 0.76)
+        XCTAssertEqual(executedBlocks, ["C"])
+
+        // Test that blocks are executed in the correct order when going forward.
+        executedBlocks = []
+        executor.executeBlocks(from: 0, .inclusive, to: 1)
+        XCTAssertEqual(executedBlocks, ["A", "B", "C"])
+
+        // Test that blocks are executed in the correct order when going in reverse.
+        executedBlocks = []
+        executor.executeBlocks(from: 1, .inclusive, to: 0)
+        XCTAssertEqual(executedBlocks, ["C'", "B'", "A'"])
+    }
+
+    func testExecutionBlocksWithCurvedAnimation() {
+        var executedBlocks: [String] = []
+
+        var animation = Animation<Element>()
+        animation.addExecution(
+            onForward: { _ in executedBlocks.append("B") },
+            onReverse: { _ in executedBlocks.append("B'") },
+            at: 0.5
+        )
+
+        // Apply a parabolic easing curve. We can calculate the uncurved timestamp at which the assignment should occur
+        // by taking the square root of the curved timestamp.
+        animation.curve = ParabolicEaseInAnimationCurve()
+
+        let element = Element()
+        let executor = Executor(animation: animation, element: element)
+
+        executor.executeBlocks(from: 0, .inclusive, to: 0.7)
+        XCTAssertEqual(executedBlocks, [])
+
+        executedBlocks = []
+        executor.executeBlocks(from: 0.7, .exclusive, to: 0.71)
+        XCTAssertEqual(executedBlocks, ["B"])
+
+        executedBlocks = []
+        executor.executeBlocks(from: 0.71, .exclusive, to: 1)
+        XCTAssertEqual(executedBlocks, [])
+
+        executedBlocks = []
+        executor.executeBlocks(from: 1, .exclusive, to: 0.71)
+        XCTAssertEqual(executedBlocks, [])
+
+        executedBlocks = []
+        executor.executeBlocks(from: 0.71, .inclusive, to: 0.7)
+        XCTAssertEqual(executedBlocks, ["B'"])
+
+        executedBlocks = []
+        executor.executeBlocks(from: 0.7, .exclusive, to: 0)
+        XCTAssertEqual(executedBlocks, [])
+    }
+
+    func testExecutionBlocksInCurvedChildAnimation() {
+        var executedBlocks: [String] = []
+
+        var childAnimation = Animation<Element>()
+        childAnimation.addExecution(
+            onForward: { _ in executedBlocks.append("B") },
+            onReverse: { _ in executedBlocks.append("B'") },
+            at: 0.5
+        )
+
+        // Apply a parabolic easing curve. We can calculate the uncurved timestamp at which the assignment should occur
+        // by taking the square root of the curved timestamp.
+        childAnimation.curve = ParabolicEaseInAnimationCurve()
+
+        var parentAnimation = Animation<Element>()
+        parentAnimation.addChild(childAnimation, for: \.self, startingAt: 0.3, relativeDuration: 0.6)
+
+        let element = Element()
+        let executor = Executor(animation: parentAnimation, element: element)
+
+        executor.executeBlocks(from: 0, .inclusive, to: 0.72)
+        XCTAssertEqual(executedBlocks, [])
+
+        executedBlocks = []
+        executor.executeBlocks(from: 0.72, .exclusive, to: 0.73)
+        XCTAssertEqual(executedBlocks, ["B"])
+
+        executedBlocks = []
+        executor.executeBlocks(from: 0.73, .exclusive, to: 1)
+        XCTAssertEqual(executedBlocks, [])
+
+        executedBlocks = []
+        executor.executeBlocks(from: 1, .exclusive, to: 0.73)
+        XCTAssertEqual(executedBlocks, [])
+
+        executedBlocks = []
+        executor.executeBlocks(from: 0.73, .inclusive, to: 0.72)
+        XCTAssertEqual(executedBlocks, ["B'"])
+
+        executedBlocks = []
+        executor.executeBlocks(from: 0.72, .exclusive, to: 0)
+        XCTAssertEqual(executedBlocks, [])
+    }
+
+}
+
+// MARK: -
+
+extension ExecutorTests {
+
+    private final class Element {
+
+        // MARK: - Life Cycle
+
+        init(
+            property: String = ""
+        ) {
+            self.property = property
+        }
+
+        // MARK: - Public Properties
+
+        var property: String
+
+    }
+
+}

--- a/Sources/Stagehand/Animation/Animation.swift
+++ b/Sources/Stagehand/Animation/Animation.swift
@@ -254,8 +254,9 @@ public struct Animation<ElementType: AnyObject> {
     /// provides a value outside of the range [0,1]).
     ///
     /// - parameter property: The key path for the property to be assigned.
-    /// - parameter relativeTimestamp: The relative timestamp at which this should be the value of the property. Must
-    /// be in the range [0,1], where 0 is the beginning of the animation and 1 is the end.
+    /// - parameter relativeTimestamp: The relative timestamp at which this should be the value of the property, based
+    /// on the curved progress of the animation. Must be in the range [0,1], where 0 is the beginning of the animation
+    /// and 1 is the end.
     /// - parameter value: The value to assign to the property.
     public mutating func addAssignment<PropertyType>(
         for property: WritableKeyPath<ElementType, PropertyType>,
@@ -304,8 +305,9 @@ public struct Animation<ElementType: AnyObject> {
     ///
     /// - parameter forwardBlock: The closure to execute when the animation is run in the forward direction.
     /// - parameter reverseBlock: The closure to execute when the animation is run in the reverse direction.
-    /// - parameter relativeTimestamp: The relative timestamp at which this should be the value of the property. Must
-    /// be in the range [0,1], where 0 is the beginning of the animation and 1 is the end.
+    /// - parameter relativeTimestamp: The relative timestamp at which this should be the value of the property, based
+    /// on the curved progress of the animation. Must be in the range [0,1], where 0 is the beginning of the animation
+    /// and 1 is the end.
     public mutating func addExecution(
         onForward forwardBlock: @escaping (ElementType) -> Void,
         onReverse reverseBlock: @escaping (ElementType) -> Void = { _ in },

--- a/Sources/Stagehand/AnimationCurve/AnimationCurve+CubicBezier.swift
+++ b/Sources/Stagehand/AnimationCurve/AnimationCurve+CubicBezier.swift
@@ -38,6 +38,14 @@ public struct CubicBezierAnimationCurve: AnimationCurve {
     // MARK: - Animation Curve
 
     public func adjustedProgress(for progress: Double) -> Double {
+        // Since the curve always starts at `(0,0)` and ends at `(1,1)`, these values should always be the same. Early
+        // return with the appropriate values here to avoid extra work and potential for rounding error.
+        if progress == 0 {
+            return 0
+        } else if progress == 1 {
+            return 1
+        }
+
         // The animation curve is defined as a cubic bezier curve where the x-axis is the raw progress and the y-axis is
         // the adjusted progress.
 

--- a/Sources/Stagehand/AnimationInstance/Executor.swift
+++ b/Sources/Stagehand/AnimationInstance/Executor.swift
@@ -1,0 +1,266 @@
+//
+//  Copyright 2020 Square Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Foundation
+
+internal final class Executor {
+
+    // MARK: - Life Cycle
+
+    internal init<ElementType: AnyObject>(
+        animation: Animation<ElementType>,
+        element: ElementType
+    ) {
+        self.rootExecutionGroup = Executor.makeExecutionGroup(animation: animation, element: element)
+            ?? ExecutionGroup(sortedExecutionBlocks: [], curve: LinearAnimationCurve(), children: [])
+    }
+
+    // MARK: - Private Properties
+
+    private var rootExecutionGroup: ExecutionGroup
+
+    // MARK: - Internal Methods
+
+    internal func executeBlocks(
+        from startingRelativeTimestamp: Double,
+        _ fromInclusivity: Inclusivity,
+        to endingRelativeTimestamp: Double
+    ) {
+        executeBlocks(
+            in: &rootExecutionGroup,
+            from: startingRelativeTimestamp,
+            fromInclusivity: fromInclusivity,
+            to: endingRelativeTimestamp
+        )
+    }
+
+    // MARK: - Private Methods
+
+    private func executeBlocks(
+        in group: inout ExecutionGroup,
+        from uncurvedStartingRelativeTimestamp: Double,
+        fromInclusivity uncurvedFromInclusivity: Inclusivity,
+        to uncurvedEndingRelativeTimestamp: Double
+    ) {
+        // Apply the animation curve to the start/end timestamps.
+        let startingRelativeTimestamp = group.curve.adjustedProgress(
+            for: uncurvedStartingRelativeTimestamp.clamped(in: 0...1)
+        )
+        let fromInclusivity = ((0...1).contains(uncurvedStartingRelativeTimestamp) ? uncurvedFromInclusivity : .inclusive)
+        let endingRelativeTimestamp = group.curve.adjustedProgress(
+            for: uncurvedEndingRelativeTimestamp.clamped(in: 0...1)
+        )
+
+        if endingRelativeTimestamp >= startingRelativeTimestamp {
+            // Iterate forward through the execution blocks.
+            for (index, executionBlock) in group.sortedExecutionBlocks.enumerated() {
+                let relativeTimestamp = executionBlock.relativeTimestamp
+                if fromInclusivity.forwardFromCompare(relativeTimestamp, startingRelativeTimestamp) && relativeTimestamp <= endingRelativeTimestamp {
+                    // Perform the forward invocation of the execution block. When executing a property assignment, the
+                    // forward block will set the reverse block, so update the stored execution block.
+                    var executionBlock = executionBlock
+                    executionBlock.forwardBlock(&executionBlock)
+                    group.sortedExecutionBlocks[index] = executionBlock
+                }
+            }
+
+        } else {
+            // Iterate in reverse through the execution blocks.
+            for executionBlock in group.sortedExecutionBlocks.reversed() {
+                let relativeTimestamp = executionBlock.relativeTimestamp
+                if fromInclusivity.reverseFromCompare(relativeTimestamp, startingRelativeTimestamp) && relativeTimestamp >= endingRelativeTimestamp {
+                    executionBlock.reverseBlock()
+                }
+            }
+        }
+
+        let executionRange = ClosedRange(unorderedBounds: (startingRelativeTimestamp, endingRelativeTimestamp))
+
+        for childIndex in group.children.indices {
+            let child = group.children[childIndex]
+
+            let childRange = (child.startingRelativeTimestamp)...(child.endingRelativeTimestamp)
+            guard executionRange.overlaps(childRange) else {
+                continue
+            }
+
+            // Find the start and end points relative to the child's timeline by reinterpolating over time in which the
+            // child animation should take place.
+            let startingTimestampInChild = (startingRelativeTimestamp - child.startingRelativeTimestamp) / child.relativeDuration
+            let endingTimestampInChild = (endingRelativeTimestamp - child.startingRelativeTimestamp) / child.relativeDuration
+
+            executeBlocks(
+                in: &group.children[childIndex].group,
+                from: startingTimestampInChild,
+                fromInclusivity: fromInclusivity,
+                to: endingTimestampInChild
+            )
+        }
+    }
+
+    // MARK: - Private Static Methods
+
+    private static func makeExecutionGroup<ElementType: AnyObject>(
+        animation: Animation<ElementType>,
+        element: ElementType
+    ) -> ExecutionGroup? {
+        let executionBlocks: [ExecutionBlock] = animation.executionBlocks
+            .map { executionBlock in
+                return ExecutionBlock(
+                    relativeTimestamp: executionBlock.relativeTimestamp,
+                    forwardBlock: { [weak element] _ in
+                        guard let element = element else {
+                            return
+                        }
+
+                        executionBlock.forwardBlock(element)
+                    },
+                    reverseBlock: { [weak element] in
+                        guard let element = element else {
+                            return
+                        }
+
+                        executionBlock.reverseBlock(element)
+                    }
+                )
+            }
+
+        let assignmentBlocks: [ExecutionBlock] = animation.assignments
+            .map { assignment in
+                return ExecutionBlock(
+                    relativeTimestamp: assignment.relativeTimestamp,
+                    forwardBlock: { [weak element] executionBlock in
+                        guard let element = element else {
+                            return
+                        }
+
+                        let reverseAssignment = assignment.generateReverseAssignBlock(element)
+                        executionBlock.reverseBlock = { [weak element] in
+                            guard let element = element else {
+                                return
+                            }
+
+                            reverseAssignment(element)
+                        }
+
+                        assignment.assignBlock(element)
+                    },
+                    reverseBlock: {
+                        // No-op. This block will be replaced when the `forwardBlock` is invoked.
+                    }
+                )
+            }
+
+        let sortedExecutionBlocks = (executionBlocks + assignmentBlocks)
+            .sorted { $0.relativeTimestamp < $1.relativeTimestamp }
+
+        let children: [ChildGroup] = animation.children.compactMap { child in
+            guard let childGroup = makeExecutionGroup(animation: child.animation, element: element) else {
+                return nil
+            }
+
+            return .init(
+                group: childGroup,
+                startingRelativeTimestamp: child.relativeStartTimestamp,
+                relativeDuration: child.relativeDuration
+            )
+        }
+
+        guard !sortedExecutionBlocks.isEmpty || !children.isEmpty else {
+            return nil
+        }
+
+        return ExecutionGroup(
+            sortedExecutionBlocks: sortedExecutionBlocks,
+            curve: animation.curve,
+            children: children
+        )
+    }
+
+}
+
+// MARK: -
+
+extension Executor {
+
+    internal enum Inclusivity {
+
+        case inclusive
+        case exclusive
+
+        // MARK: - Private Computed Properties
+
+        fileprivate var forwardFromCompare: (Double, Double) -> Bool {
+            switch self {
+            case .inclusive:
+                return (>=)
+            case .exclusive:
+                return (>)
+            }
+        }
+
+        fileprivate var reverseFromCompare: (Double, Double) -> Bool {
+            switch self {
+            case .inclusive:
+                return (<=)
+            case .exclusive:
+                return (<)
+            }
+        }
+
+    }
+
+}
+
+// MARK: -
+
+extension Executor {
+
+    private struct ExecutionGroup {
+
+        var sortedExecutionBlocks: [ExecutionBlock]
+
+        var curve: AnimationCurve
+
+        var children: [ChildGroup]
+
+    }
+
+    private struct ChildGroup {
+
+        var group: ExecutionGroup
+
+        var startingRelativeTimestamp: Double
+
+        var relativeDuration: Double
+
+        var endingRelativeTimestamp: Double {
+            return startingRelativeTimestamp + relativeDuration
+        }
+
+    }
+
+    private struct ExecutionBlock {
+
+        var relativeTimestamp: Double
+
+        var forwardBlock: (inout ExecutionBlock) -> Void
+
+        var reverseBlock: () -> Void
+
+    }
+
+}

--- a/Sources/Stagehand/AnimationInstance/Executor.swift
+++ b/Sources/Stagehand/AnimationInstance/Executor.swift
@@ -243,10 +243,13 @@ extension Executor {
 
         var group: ExecutionGroup
 
+        /// The timestamp at which the child animation begins, relative to the parent animation's timeline.
         var startingRelativeTimestamp: Double
 
+        /// The duration over which the child animation occurs, relative to the parent animation's timeline.
         var relativeDuration: Double
 
+        /// The timestamp at which the child animation ends, relative to the parent animation's timeline.
         var endingRelativeTimestamp: Double {
             return startingRelativeTimestamp + relativeDuration
         }
@@ -255,6 +258,7 @@ extension Executor {
 
     private struct ExecutionBlock {
 
+        /// The timestamp at which the block should be executed, relative to the animation's timeline.
         var relativeTimestamp: Double
 
         var forwardBlock: (inout ExecutionBlock) -> Void

--- a/Sources/Stagehand/Driver/Driver.swift
+++ b/Sources/Stagehand/Driver/Driver.swift
@@ -39,7 +39,7 @@ protocol DrivenAnimationInstance: AnyObject {
 
     func executeBlocks(
         from startingRelativeTimestamp: Double,
-        _ fromInclusivity: AnimationInstance.Inclusivity,
+        _ fromInclusivity: Executor.Inclusivity,
         to endingRelativeTimestamp: Double
     )
 

--- a/Sources/Stagehand/Utilities/ClosedRange+Additions.swift
+++ b/Sources/Stagehand/Utilities/ClosedRange+Additions.swift
@@ -1,0 +1,29 @@
+//
+//  Copyright 2020 Square Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Foundation
+
+extension ClosedRange {
+
+    internal init(unorderedBounds bounds: (Bound, Bound)) {
+        if bounds.0 < bounds.1 {
+            self = (bounds.0...bounds.1)
+        } else {
+            self = (bounds.1...bounds.0)
+        }
+    }
+
+}


### PR DESCRIPTION
* Updates execution blocks and property assignments to be executed based on the curved progress. Execution blocks were previously executed based on the uncurved progress, rather than the curved progress, but this was unintentional (see #18). Property assignments were previously being adjusted in the wrong direction.

* Fixes the reverse block of a property assignment holding onto the element strongly.

Resolves #26.