### PR TITLE
Add GitHub Actions for CI builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,11 +27,8 @@ jobs:
         if: matrix.platform == 'iOS_12'
       - name: Pod Install
         run: bundle exec --gemfile=Example/Gemfile pod install --project-directory=Example
-      - name: Find xcpretty
-        id: find-xcpretty
-        run: echo "::set-output name=xcpretty-path::"`which xcpretty`
       - name: Build and Test
-        run: Scripts/build.swift xcode ${{ matrix.platform }} ${{ steps.find-xcpretty.outputs.xcpretty-path }}
+        run: Scripts/build.swift xcode ${{ matrix.platform }} `which xcpretty`
       - name: Upload Results
         uses: actions/upload-artifact@v2
         if: failure()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,13 +27,11 @@ jobs:
         if: matrix.platform == 'iOS_12'
       - name: Pod Install
         run: bundle exec --gemfile=Example/Gemfile pod install --project-directory=Example
-      - name: Install xcpretty
-        id: install-xcpretty
-        run: |
-          gem install xcpretty
-          echo "::set-output name=xcpretty-path::"`which xcpretty`
+      - name: Find xcpretty
+        id: find-xcpretty
+        run: echo "::set-output name=xcpretty-path::"`which xcpretty`
       - name: Build and Test
-        run: Scripts/build.swift xcode ${{ matrix.platform }} ${{ steps.install-xcpretty.outputs.xcpretty-path }}
+        run: Scripts/build.swift xcode ${{ matrix.platform }} ${{ steps.find-xcpretty.outputs.xcpretty-path }}
       - name: Upload Results
         uses: actions/upload-artifact@v2
         if: failure()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,70 @@
+name: CI
+
+on:
+  push:
+    branches:
+    - master
+  pull_request:
+
+jobs:
+  xcode-build:
+    name: Xcode Build
+    runs-on: macOS-latest
+    strategy:
+      matrix:
+        platform: ['iOS_13', 'iOS_12']
+      fail-fast: false
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v2
+      - name: Bundle Install
+        run: bundle install --gemfile=Example/Gemfile
+      - name: Select Xcode Version (11.3.1)
+        run: sudo xcode-select --switch /Applications/Xcode_11.3.1.app/Contents/Developer
+        if: matrix.platform == 'iOS_13'
+      - name: Select Xcode Version (10.3)
+        run: sudo xcode-select --switch /Applications/Xcode_10.3.app/Contents/Developer
+        if: matrix.platform == 'iOS_12'
+      - name: Pod Install
+        run: bundle exec --gemfile=Example/Gemfile pod install --project-directory=Example
+      - name: Install xcpretty
+        id: install-xcpretty
+        run: |
+          gem install xcpretty
+          echo "::set-output name=xcpretty-path::"`which xcpretty`
+      - name: Build and Test
+        run: Scripts/build.swift xcode ${{ matrix.platform }} ${{ steps.install-xcpretty.outputs.xcpretty-path }}
+      - name: Upload Results
+        uses: actions/upload-artifact@v2
+        if: failure()
+        with:
+          name: Test Results
+          path: .build/derivedData/**/Logs/Test/*.xcresult
+  pod-lint:
+    name: Pod Lint
+    runs-on: macOS-latest
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v2
+      - name: Bundle Install
+        run: bundle install --gemfile=Example/Gemfile
+      - name: Pod Install
+        run: bundle exec --gemfile=Example/Gemfile pod install --project-directory=Example
+      - name: Lint Stagehand Podspec
+        run: bundle exec --gemfile=Example/Gemfile pod lib lint --verbose --fail-fast Stagehand.podspec
+      - name: Lint StagehandTesting Podspec
+        run: bundle exec --gemfile=Example/Gemfile pod lib lint --verbose --fail-fast --external-podspecs=Stagehand.podspec StagehandTesting.podspec
+  spm:
+    name: SPM Build
+    runs-on: macOS-latest
+    strategy:
+      matrix:
+        platform: ['iOS_13']
+      fail-fast: false
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v2
+      - name: Select Xcode Version (11.3.1)
+        run: sudo xcode-select --switch /Applications/Xcode_11.3.1.app/Contents/Developer
+      - name: Build
+        run: Scripts/build.swift spm ${{ matrix.platform }}

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,11 @@
 language: objective-c
 jobs:
-  - osx_image: xcode11.3
-    env: ACTIONS="xcode,pod-lint";PLATFORM="iOS_13"
   - osx_image: xcode10.3
-    env: ACTIONS="xcode,pod-lint";PLATFORM="iOS_12"
+    env: ACTIONS="pod-lint"
   - osx_image: xcode10.3
-    env: ACTIONS="xcode,pod-lint";PLATFORM="iOS_11"
+    env: ACTIONS="xcode";PLATFORM="iOS_11"
   - osx_image: xcode10.3
-    env: ACTIONS="xcode,pod-lint";PLATFORM="iOS_10"
-  - osx_image: xcode11.3
-    env: ACTIONS="spm";PLATFORM="iOS_13"
+    env: ACTIONS="xcode";PLATFORM="iOS_10"
 install:
   - bundle install --gemfile=Example/Gemfile
   - bundle exec --gemfile=Example/Gemfile pod install --project-directory=Example

--- a/Scripts/build.swift
+++ b/Scripts/build.swift
@@ -64,6 +64,10 @@ enum Platform: String, CustomStringConvertible {
 		}
 	}
 
+	var derivedDataPath: String {
+		return ".build/derivedData/\(rawValue)"
+	}
+
 	var description: String {
 		return rawValue
 	}
@@ -161,6 +165,7 @@ xcodeBuildArguments.append(
 		"-sdk", "iphonesimulator",
 		"-PBXBuildsContinueAfterErrors=0",
 		"-destination", platform.destination,
+		"-derivedDataPath", platform.derivedDataPath,
 		"ONLY_ACTIVE_ARCH=NO",
 	]
 )


### PR DESCRIPTION
This moves us to a combination of GitHub Actions and Travis CI for our CI builds. This separation prefers GitHub Actions when available, since it has some advantages (more concurrent builds, artifact upload, etc.), but falls back to Travis CI for iOS versions that aren't easily supported with GitHub Actions.