### PR TITLE
Update CI badge on README to show GitHub Actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Stagehand
 
-[![CI Status](https://img.shields.io/travis/CashApp/Stagehand/master.svg?style=flat)](https://travis-ci.org/CashApp/Stagehand)
+[![CI Status](https://img.shields.io/github/workflow/status/cashapp/stagehand/CI/master)](https://github.com/cashapp/stagehand/actions?query=workflow%3ACI+branch%3Amaster)
 [![Version](https://img.shields.io/cocoapods/v/Stagehand.svg?style=flat)](https://cocoapods.org/pods/Stagehand)
 [![License](https://img.shields.io/cocoapods/l/Stagehand.svg?style=flat)](https://cocoapods.org/pods/Stagehand)
 [![Platform](https://img.shields.io/cocoapods/p/Stagehand.svg?style=flat)](https://cocoapods.org/pods/Stagehand)


### PR DESCRIPTION
The CI badge was previously showing the status of the travis-ci.org build. This build has since been disabled with the move to travis-ci.com, so the badge wasn't showing the current build status.

This updates the badge to show the status of the GitHub Actions CI build for master.

Alternatively, we could show two badges: one for GitHub Actions and one for Travis (using the travis-ci.com status). This would accurately represent the fact that our CI is split across the two systems, but I think showing one badge is cleaner and we've moved most of the builds to GitHub Actions, with Travis only handling legacy iOS and Xcode versions, so I think the GitHub Actions status is more important to show.