### PR TITLE
Be more explicit about types in unit tests

### DIFF
--- a/Example/Unit Tests/CGAffineTransformInterpolationSnapshotTests.swift
+++ b/Example/Unit Tests/CGAffineTransformInterpolationSnapshotTests.swift
@@ -58,12 +58,12 @@ final class CGAffineTransformInterpolationSnapshotTests: SnapshotTestCase {
     func testRotation() {
         snapshotVerifyAnimation(
             transforms: [
-                .init(rotationAngle: .pi / 4),
-                .init(rotationAngle: -.pi / 4),
+                .init(rotationAngle: CGFloat.pi / 4),
+                .init(rotationAngle: -CGFloat.pi / 4),
 
                 // Test that rotation across π/-π behave as expected.
-                .init(rotationAngle: CGFloat(.pi - 0.5)),
-                .init(rotationAngle: CGFloat(-.pi + 0.5)),
+                .init(rotationAngle: CGFloat.pi - 0.5),
+                .init(rotationAngle: -CGFloat.pi + 0.5),
             ]
         )
     }


### PR DESCRIPTION
Xcode 12 was having trouble resolving the types here. Specifying that `.pi` is meant to be a `CGFloat` seems to make it happy.

This addresses part of #44.