### PR TITLE
Organize demo screens into categories

### DIFF
--- a/Example/Stagehand.xcodeproj/project.pbxproj
+++ b/Example/Stagehand.xcodeproj/project.pbxproj
@@ -186,23 +186,18 @@
 		3D75A7C42292891100743166 /* Demo View Controllers */ = {
 			isa = PBXGroup;
 			children = (
-				3D75A7C52292892B00743166 /* SimpleAnimationsViewController.swift */,
-				3D75A7C72292910B00743166 /* RelativeAnimationsViewController.swift */,
-				3DB3927C23249D680009E8B3 /* ColorAnimationsViewController.swift */,
-				3D1D304922F007B7003E392C /* ChildAnimationsViewController.swift */,
-				3DBFEE412400B2460086D61C /* ChildAnimationProgressViewController.swift */,
-				3D1D304B22F01136003E392C /* AnimationCurveViewController.swift */,
-				3D8E3D7F22F16C1B00D70FCB /* ChildAnimationsWithCurvesViewController.swift */,
-				3D8E3D8122F17D3B00D70FCB /* AnimationCancelationViewController.swift */,
-				3D89F1E122FDEAAC008AC33E /* PropertyAssignmentViewController.swift */,
-				3D8E3D8322F2BC9300D70FCB /* RepeatingAnimationsViewController.swift */,
-				3DA3997B230FCFAC00DE41A0 /* ExecutionBlockViewController.swift */,
-				3DEE4409231331DD0057D796 /* AnimationGroupViewController.swift */,
-				3D875EFF2323542500670803 /* PerformanceBenchmarkViewController.swift */,
-				3D2712ED236A17C5001D3B4B /* AnimationQueueViewController.swift */,
-				3D2C05902489F807003F5A4B /* CGAffineTransformDebuggingViewController.swift */,
+				3D763D0525252E6D00D9525C /* Demo Screens */,
+				3DFA5473250F7361001CB420 /* Feature Screens */,
+				3DFA5474250F7389001CB420 /* Debugging Screens */,
 			);
 			name = "Demo View Controllers";
+			sourceTree = "<group>";
+		};
+		3D763D0525252E6D00D9525C /* Demo Screens */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			name = "Demo Screens";
 			sourceTree = "<group>";
 		};
 		3DC75495232F6D3800402BD9 /* Utilities */ = {
@@ -213,6 +208,35 @@
 				3DC75496232F6D5500402BD9 /* TestDriver.swift */,
 			);
 			name = Utilities;
+			sourceTree = "<group>";
+		};
+		3DFA5473250F7361001CB420 /* Feature Screens */ = {
+			isa = PBXGroup;
+			children = (
+				3D75A7C52292892B00743166 /* SimpleAnimationsViewController.swift */,
+				3D75A7C72292910B00743166 /* RelativeAnimationsViewController.swift */,
+				3DB3927C23249D680009E8B3 /* ColorAnimationsViewController.swift */,
+				3D1D304922F007B7003E392C /* ChildAnimationsViewController.swift */,
+				3D1D304B22F01136003E392C /* AnimationCurveViewController.swift */,
+				3D8E3D7F22F16C1B00D70FCB /* ChildAnimationsWithCurvesViewController.swift */,
+				3D8E3D8122F17D3B00D70FCB /* AnimationCancelationViewController.swift */,
+				3D89F1E122FDEAAC008AC33E /* PropertyAssignmentViewController.swift */,
+				3D8E3D8322F2BC9300D70FCB /* RepeatingAnimationsViewController.swift */,
+				3DA3997B230FCFAC00DE41A0 /* ExecutionBlockViewController.swift */,
+				3DEE4409231331DD0057D796 /* AnimationGroupViewController.swift */,
+				3D2712ED236A17C5001D3B4B /* AnimationQueueViewController.swift */,
+			);
+			name = "Feature Screens";
+			sourceTree = "<group>";
+		};
+		3DFA5474250F7389001CB420 /* Debugging Screens */ = {
+			isa = PBXGroup;
+			children = (
+				3DBFEE412400B2460086D61C /* ChildAnimationProgressViewController.swift */,
+				3D875EFF2323542500670803 /* PerformanceBenchmarkViewController.swift */,
+				3D2C05902489F807003F5A4B /* CGAffineTransformDebuggingViewController.swift */,
+			);
+			name = "Debugging Screens";
 			sourceTree = "<group>";
 		};
 		551ED7281AD3CB63D20C62B2 /* Pods */ = {

--- a/Example/Stagehand/RootViewController.swift
+++ b/Example/Stagehand/RootViewController.swift
@@ -33,28 +33,43 @@ final class RootViewController: UITableViewController {
 
     // MARK: - Private Properties
 
-    private let demoScreens: [(name: String, viewControllerFactory: () -> UIViewController)] = [
-        ("Simple Animations", { SimpleAnimationsViewController() }),
-        ("Relative Animations", { RelativeAnimationsViewController() }),
-        ("Color Animations", { ColorAnimationsViewController() }),
+    private typealias RowModel = (name: String, viewControllerFactory: () -> UIViewController)
+
+    /// Screens that show an example of a complete animation.
+    private let demoScreens: [RowModel] = [
+    ]
+
+    /// Screens that show how a specific feature can be used.
+    private let featureScreens: [RowModel] = [
+        ("Simple Keyframe Animations", { SimpleAnimationsViewController() }),
+        ("Relative Keyframe Animations", { RelativeAnimationsViewController() }),
+        ("Color Keyframe Animations", { ColorAnimationsViewController() }),
         ("Child Animations", { ChildAnimationsViewController() }),
         ("Animation Curves", { AnimationCurveViewController() }),
         ("Child Animations with Curves", { ChildAnimationsWithCurvesViewController() }),
-        ("Child Animation Progress", { ChildAnimationProgressViewController() }),
         ("Animation Cancellation", { AnimationCancelationViewController() }),
         ("Property Assignments", { PropertyAssignmentViewController() }),
         ("Repeating Animations", { RepeatingAnimationsViewController() }),
         ("Execution Blocks", { ExecutionBlockViewController() }),
         ("Animation Groups", { AnimationGroupViewController() }),
-        ("Performance Benchmark", { PerformanceBenchmarkViewController() }),
         ("Animation Queues", { AnimationQueueViewController() }),
+    ]
+
+    /// Screens that are used for debugging specific functionality.
+    private let debuggingScreens: [RowModel] = [
+        ("Child Animation Progress", { ChildAnimationProgressViewController() }),
+        ("Performance Benchmark", { PerformanceBenchmarkViewController() }),
         ("CGAffineTransform Debugging", { CGAffineTransformDebuggingViewController() }),
     ]
 
     // MARK: - UITableViewController
 
+    override func numberOfSections(in tableView: UITableView) -> Int {
+        return Section.allCases.count
+    }
+
     override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        return demoScreens.count
+        return rows(for: Section(rawValue: section)!).count
     }
 
     override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
@@ -62,14 +77,46 @@ final class RootViewController: UITableViewController {
     }
 
     override func tableView(_ tableView: UITableView, willDisplay cell: UITableViewCell, forRowAt indexPath: IndexPath) {
-        let screen = demoScreens[indexPath.row]
+        let screen = rows(for: Section(rawValue: indexPath.section)!)[indexPath.row]
         cell.textLabel?.text = screen.name
     }
 
     override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
-        let screen = demoScreens[indexPath.row]
+        let screen = rows(for: Section(rawValue: indexPath.section)!)[indexPath.row]
         navigationController?.pushViewController(screen.viewControllerFactory(), animated: true)
         tableView.deselectRow(at: indexPath, animated: true)
+    }
+
+    override func tableView(_ tableView: UITableView, titleForHeaderInSection section: Int) -> String? {
+        switch Section(rawValue: section)! {
+        case .integrationDemos:
+            return "Sample Animations"
+        case .featureDemos:
+            return "Feature Explorations"
+        case .debuggingTools:
+            return "Debugging Tools"
+        }
+    }
+
+    // MARK: - Private Methods
+
+    private func rows(for section: Section) -> [RowModel] {
+        switch section {
+        case .integrationDemos:
+            return demoScreens
+        case .featureDemos:
+            return featureScreens
+        case .debuggingTools:
+            return debuggingScreens
+        }
+    }
+
+    // MARK: - Private Types
+
+    private enum Section: Int, CaseIterable {
+        case integrationDemos
+        case featureDemos
+        case debuggingTools
     }
 
 }


### PR DESCRIPTION
This organizes the demo screens into three categories:

1.  Screens that show off an example of a real use case

2.  Screens that demonstrate specific functionality

3.  Screens that help with debugging functionality

Resolves #32 