### PR TITLE
Split CI jobs into separate workflows

### DIFF
--- a/.github/workflows/pod-lint.yml
+++ b/.github/workflows/pod-lint.yml
@@ -1,0 +1,23 @@
+name: CI
+
+on:
+  push:
+    branches:
+    - master
+  pull_request:
+
+jobs:
+  pod-lint:
+    name: Pod Lint
+    runs-on: macOS-latest
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v2
+      - name: Bundle Install
+        run: bundle install --gemfile=Example/Gemfile
+      - name: Pod Install
+        run: bundle exec --gemfile=Example/Gemfile pod install --project-directory=Example
+      - name: Lint Stagehand Podspec
+        run: bundle exec --gemfile=Example/Gemfile pod lib lint --verbose --fail-fast Stagehand.podspec
+      - name: Lint StagehandTesting Podspec
+        run: bundle exec --gemfile=Example/Gemfile pod lib lint --verbose --fail-fast --include-podspecs=Stagehand.podspec StagehandTesting.podspec

--- a/.github/workflows/spm-build.yml
+++ b/.github/workflows/spm-build.yml
@@ -1,0 +1,23 @@
+name: CI
+
+on:
+  push:
+    branches:
+    - master
+  pull_request:
+
+jobs:
+  spm:
+    name: SPM Build
+    runs-on: macOS-latest
+    strategy:
+      matrix:
+        platform: ['iOS_13']
+      fail-fast: false
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v2
+      - name: Select Xcode Version (11.3.1)
+        run: sudo xcode-select --switch /Applications/Xcode_11.3.1.app/Contents/Developer
+      - name: Build
+        run: Scripts/build.swift spm ${{ matrix.platform }}

--- a/.github/workflows/xcode-build.yml
+++ b/.github/workflows/xcode-build.yml
@@ -35,31 +35,3 @@ jobs:
         with:
           name: Test Results
           path: .build/derivedData/**/Logs/Test/*.xcresult
-  pod-lint:
-    name: Pod Lint
-    runs-on: macOS-latest
-    steps:
-      - name: Checkout Repo
-        uses: actions/checkout@v2
-      - name: Bundle Install
-        run: bundle install --gemfile=Example/Gemfile
-      - name: Pod Install
-        run: bundle exec --gemfile=Example/Gemfile pod install --project-directory=Example
-      - name: Lint Stagehand Podspec
-        run: bundle exec --gemfile=Example/Gemfile pod lib lint --verbose --fail-fast Stagehand.podspec
-      - name: Lint StagehandTesting Podspec
-        run: bundle exec --gemfile=Example/Gemfile pod lib lint --verbose --fail-fast --include-podspecs=Stagehand.podspec StagehandTesting.podspec
-  spm:
-    name: SPM Build
-    runs-on: macOS-latest
-    strategy:
-      matrix:
-        platform: ['iOS_13']
-      fail-fast: false
-    steps:
-      - name: Checkout Repo
-        uses: actions/checkout@v2
-      - name: Select Xcode Version (11.3.1)
-        run: sudo xcode-select --switch /Applications/Xcode_11.3.1.app/Contents/Developer
-      - name: Build
-        run: Scripts/build.swift spm ${{ matrix.platform }}


### PR DESCRIPTION
Since GitHub Actions doesn't allow for restarting a single job, this breaks our large CI workflow into separate workflows for each of the job types. This makes it easier to debug flaky builds without having to restart as many jobs.