### PR TITLE
Fix ambigious usage of CGAffineTransform.decomposed

### DIFF
--- a/Sources/Stagehand/AnimatableProperty/AnimatableProperty+CGAffineTransform.swift
+++ b/Sources/Stagehand/AnimatableProperty/AnimatableProperty+CGAffineTransform.swift
@@ -28,8 +28,8 @@ extension CGAffineTransform: AnimatableProperty {
         and finalValue: CGAffineTransform,
         at progress: Double
     ) -> CGAffineTransform {
-        var initialDecomposition = initialValue.decomposed()
-        var finalDecomposition = finalValue.decomposed()
+        var initialDecomposition: DecomposedMatrix = initialValue.decomposed()
+        var finalDecomposition: DecomposedMatrix = finalValue.decomposed()
 
         // Prefer rotating over scaling when possible.
         let flippedFromNegativeXToNegativeY = initialDecomposition.scaleX < 0 && finalDecomposition.scaleY < 0


### PR DESCRIPTION
Fixes the following compile error when consuming Stagehand in some projects:

```sh
Sources/Stagehand/AnimatableProperty/AnimatableProperty+CGAffineTransform.swift:32:45: error: ambiguous use of 'decomposed()'
        var finalDecomposition = finalValue.decomposed()
                                            ^
Sources/Stagehand/AnimatableProperty/AnimatableProperty+CGAffineTransform.swift:86:10: note: found this candidate
    func decomposed() -> DecomposedMatrix {
         ^
CoreGraphics.CGAffineTransform:13:17: note: found this candidate
    public func decomposed() -> CGAffineTransformComponents
                ^
```

This is because `CGAffineTransform` now has this API:

```swift
extension CGAffineTransform {
...
    @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
    public func decomposed() -> CGAffineTransformComponents
...
}
```