### PR TITLE
Disable implicit animations while rendering initial frame

### DIFF
--- a/Sources/Stagehand/AnimationInstance/Renderer.swift
+++ b/Sources/Stagehand/AnimationInstance/Renderer.swift
@@ -70,7 +70,12 @@ internal final class Renderer<ElementType: AnyObject>: AnyRenderer {
             return
         }
 
+        CATransaction.begin()
+        CATransaction.setDisableActions(true)
+
         animation.applyInitialKeyframes(to: &element, initialValues: initialValues)
+
+        CATransaction.commit()
     }
 
 }


### PR DESCRIPTION
In #80, we disabled implicit animations for rendering during an animation, but missed applying it to the initial frame