### PR TITLE
Upgrade to iOS 13.0 minimum to support latest swift-snapshot-testing

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -21,7 +21,7 @@ import PackageDescription
 let package = Package(
 	name: "Stagehand",
 	platforms: [
-		.iOS(.v12),
+		.iOS(.v13),
 		.macOS(.v11),
 	],
 	products: [

--- a/Stagehand.podspec
+++ b/Stagehand.podspec
@@ -7,7 +7,7 @@ Pod::Spec.new do |s|
   s.author           = 'Square'
   s.source           = { :git => 'https://github.com/CashApp/Stagehand.git', :tag => s.version.to_s }
 
-  s.ios.deployment_target = '12.0'
+  s.ios.deployment_target = '13.0'
 
   s.swift_version = '5.0.1'
 

--- a/StagehandTesting.podspec
+++ b/StagehandTesting.podspec
@@ -7,7 +7,7 @@ Pod::Spec.new do |s|
   s.author           = 'Square'
   s.source           = { :git => 'https://github.com/CashApp/Stagehand.git', :tag => s.version.to_s }
 
-  s.ios.deployment_target = '12.0'
+  s.ios.deployment_target = '13.0'
 
   s.swift_version = '5.0.1'
 


### PR DESCRIPTION
Required to support newer swift-snapshot-testing versions